### PR TITLE
Fix #1 - Accept the comma-separated format

### DIFF
--- a/imageGen.py
+++ b/imageGen.py
@@ -116,7 +116,7 @@ def parseChat(you, lines):
     lines = lines.split('\n')
     appName = 'WhatsApp'
 
-    tEx = re.compile(r'(?<=[0-9] )[0-9:]+[^\]]')
+    tEx = re.compile(r'^\[[0-9/]+,? ([0-9:]+[^\]])')
     nEx = re.compile(r'(?<=\] )[a-zA-Z]+[^:]*')
     # nEx = re.compile(r'(?<= )[a-zA-Z]+:')
     # mEx = re.compile(r'(?<=[a-zA-Z]: ).*$')
@@ -154,7 +154,7 @@ def parseChat(you, lines):
         
         # print line
 
-        time = tEx.search(line).group()
+        time = tEx.search(line).group(1)
         name = nEx.search(line).group()
         message = mEx.search(line).group()
 
@@ -235,12 +235,12 @@ They just keep whining.
 [12/09 20:11] Foo: Yeah
 [12/09 20:13] Bar: And it's so irritating to see parents forcing their fear on children who have no past experience with dogs."""
 
-sampS2 = """[12/09 20:10 AM] Foo: Family friends
+sampS2 = """[12/09, 20:10 AM] Foo: Family friends
 Gigantic douchebags.
-[12/09 20:10 PM] Bar: It's always a pain in the ass to handle people like that as well as the doge.
+[12/09, 20:10 PM] Bar: It's always a pain in the ass to handle people like that as well as the doge.
 They just keep whining.
-[12/09 20:11 AM] Foo: Yeah
-[12/09 20:13 PM] Bar: And it's so irritating to see parents forcing their fear on children who have no past experience with dogs."""
+[12/09, 20:11 AM] Foo: Yeah
+[12/09, 20:13 PM] Bar: And it's so irritating to see parents forcing their fear on children who have no past experience with dogs."""
 
 # f = open('chat.txt','r')
 # lines = f.readlines()

--- a/static/chat_pretty.js
+++ b/static/chat_pretty.js
@@ -26,7 +26,7 @@ $(document).ready(function(){
          var people = [];
          for(i = 0; i < chatArr.length; i++)
          {
-             var dateTime = chatArr[i].match(/\[[0-9]+\/[0-9]+ [0-9]+:[0-9]+[( AM| PM)]*\]/g);
+             var dateTime = chatArr[i].match(/\[[0-9]+\/[0-9]+,? [0-9]+:[0-9]+[( AM| PM)]*\]/g);
              console.log(dateTime);
              if(dateTime != null)
              {
@@ -54,8 +54,7 @@ $(document).ready(function(){
                      people.push(tmp);
              }
          }
-
-         if(chatArr[0].match(/\[[0-9]+\/[0-9]+ [0-9]+:[0-9]+[( AM| PM)]*\]/g) != null)
+         if(chatArr[0].match(/\[[0-9]+\/[0-9]+,? [0-9]+:[0-9]+[( AM| PM)]*\]/g) != null)
          { 
              
              var $personChoice = $("#person-choice");


### PR DESCRIPTION
I had to change the time-extraction regex (**tEx**) to using groups for extraction rather than the _positive look-behind_ `(?<=...)` because we have to give an expression with fixed length to the _positive look-behind_ and the expression now had an optional comma so it wasn't fixed length anymore

Please do test the changes before merging :stuck_out_tongue_winking_eye: 
